### PR TITLE
fix: broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,6 @@ Thank you for taking the time to give us feedback. We monitor this repository an
 - [Report a bug](https://github.com/observablehq/feedback/issues/new?assignees=&labels=&projects=&template=bug_report.md&title=)
 - [Request a feature](https://github.com/observablehq/feedback/issues/new?assignees=&labels=&projects=&template=feature_request.md&title=)
 - [Open a blank issue](https://github.com/observablehq/feedback/issues/new)
-- [Browse existing issues](https://github.com/observablehq/idea-sandbox/issues), and remember to give a “👍” to any you agree with
+- [Browse existing issues](https://github.com/observablehq/feedback/issues), and remember to give a “👍” to any you agree with
 
 We look forward to reading what you have to say!


### PR DESCRIPTION
The URL was pointing to the wrong repository. 